### PR TITLE
:sparkles: 이메일 발송 기능 개선 및 로깅 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/team2server/Application.kt
+++ b/src/main/kotlin/com/wafflestudio/team2server/Application.kt
@@ -2,9 +2,11 @@ package com.wafflestudio.team2server
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableScheduling
+@EnableAsync
 @SpringBootApplication
 class Application
 

--- a/src/main/kotlin/com/wafflestudio/team2server/article/ArticleEventListener.kt
+++ b/src/main/kotlin/com/wafflestudio/team2server/article/ArticleEventListener.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.team2server.article.model.ArticleCreatedEvent
 import com.wafflestudio.team2server.email.service.EmailService
 import com.wafflestudio.team2server.email.service.MailService
 import com.wafflestudio.team2server.inbox.service.InboxService
+import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -14,17 +15,26 @@ class ArticleEventListener(
     private val emailService: EmailService,
     private val mailService: MailService,
 ) {
+    private val logger = LoggerFactory.getLogger(ArticleEventListener::class.java)
+
     @EventListener
     @Transactional
     fun handleArticleCreated(event: ArticleCreatedEvent) {
         val article = event.article
+        logger.info("게시글 생성 이벤트 수신: 게시글ID={}, 제목={}, 게시판ID={}", article.id, article.title, article.boardId)
 
         val recipients = emailService.getSubscriberEmails(article.boardId)
+        logger.info("이메일 구독자 조회 완료: 게시판ID={}, 구독자 수={}", article.boardId, recipients.size)
 
         inboxService.createInboxesForBoardSubscribers(article)
 
-        recipients.forEach { email ->
-            mailService.sendArticleNotification(email, article)
+        if (recipients.isEmpty()) {
+            logger.debug("이메일 발송할 구독자가 없습니다: 게시판ID={}", article.boardId)
+        } else {
+            logger.info("이메일 발송 시작: 게시판ID={}, 구독자 수={}", article.boardId, recipients.size)
+            recipients.forEach { email ->
+                mailService.sendArticleNotification(email, article)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/team2server/email/service/MailService.kt
+++ b/src/main/kotlin/com/wafflestudio/team2server/email/service/MailService.kt
@@ -25,10 +25,15 @@ class MailService(
         val port = environment.getProperty("spring.mail.port") ?: "not set"
         val username = environment.getProperty("spring.mail.username") ?: "not set"
         val hasPassword = !environment.getProperty("spring.mail.password").isNullOrBlank()
-        
-        logger.info("이메일 설정 초기화: host={}, port={}, username={}, password={}", 
-            host, port, username, if (hasPassword) "설정됨" else "설정되지 않음")
-        
+
+        logger.info(
+            "이메일 설정 초기화: host={}, port={}, username={}, password={}",
+            host,
+            port,
+            username,
+            if (hasPassword) "설정됨" else "설정되지 않음",
+        )
+
         if (!hasPassword || username == "not set") {
             logger.warn("이메일 설정이 완전하지 않습니다. MAIL_USERNAME과 MAIL_PASSWORD 환경 변수를 확인하세요.")
         }

--- a/src/main/kotlin/com/wafflestudio/team2server/email/service/MailService.kt
+++ b/src/main/kotlin/com/wafflestudio/team2server/email/service/MailService.kt
@@ -1,7 +1,10 @@
 package com.wafflestudio.team2server.email.service
 
 import com.wafflestudio.team2server.article.model.Article
+import jakarta.annotation.PostConstruct
 import jakarta.mail.internet.MimeMessage
+import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
@@ -12,12 +15,31 @@ import java.time.format.DateTimeFormatter
 @Service
 class MailService(
     private val javaMailSender: JavaMailSender,
+    private val environment: Environment,
 ) {
+    private val logger = LoggerFactory.getLogger(MailService::class.java)
+
+    @PostConstruct
+    fun logMailConfiguration() {
+        val host = environment.getProperty("spring.mail.host") ?: "not set"
+        val port = environment.getProperty("spring.mail.port") ?: "not set"
+        val username = environment.getProperty("spring.mail.username") ?: "not set"
+        val hasPassword = !environment.getProperty("spring.mail.password").isNullOrBlank()
+        
+        logger.info("이메일 설정 초기화: host={}, port={}, username={}, password={}", 
+            host, port, username, if (hasPassword) "설정됨" else "설정되지 않음")
+        
+        if (!hasPassword || username == "not set") {
+            logger.warn("이메일 설정이 완전하지 않습니다. MAIL_USERNAME과 MAIL_PASSWORD 환경 변수를 확인하세요.")
+        }
+    }
+
     @Async
     fun sendArticleNotification(
         email: String,
         article: Article,
     ) {
+        logger.info("이메일 발송 시작: 수신자={}, 제목={}, 게시글ID={}", email, article.title, article.id)
         val subject = "[새 글 알림] ${article.title}"
         val htmlBody = createHtmlBody(article)
 
@@ -30,6 +52,7 @@ class MailService(
         htmlBody: String,
     ) {
         try {
+            logger.debug("이메일 메시지 생성 시작: 수신자={}, 제목={}", to, subject)
             val message: MimeMessage = javaMailSender.createMimeMessage()
             val helper = MimeMessageHelper(message, true, "UTF-8")
 
@@ -37,8 +60,19 @@ class MailService(
             helper.setSubject(subject)
             helper.setText(htmlBody, true)
 
+            logger.debug("이메일 전송 시도: 수신자={}, 제목={}", to, subject)
             javaMailSender.send(message)
+            logger.info("이메일 발송 성공: 수신자={}, 제목={}", to, subject)
+        } catch (e: jakarta.mail.AuthenticationFailedException) {
+            logger.error("이메일 인증 실패: 수신자={}, 제목={}, 오류={}", to, subject, e.message, e)
+        } catch (e: jakarta.mail.MessagingException) {
+            logger.error("이메일 메시징 오류: 수신자={}, 제목={}, 오류={}", to, subject, e.message, e)
+        } catch (e: java.net.SocketTimeoutException) {
+            logger.error("이메일 전송 타임아웃: 수신자={}, 제목={}, 오류={}", to, subject, e.message, e)
+        } catch (e: java.net.ConnectException) {
+            logger.error("이메일 서버 연결 실패: 수신자={}, 제목={}, 오류={}", to, subject, e.message, e)
         } catch (e: Exception) {
+            logger.error("이메일 발송 실패: 수신자={}, 제목={}, 오류타입={}, 오류={}", to, subject, e.javaClass.simpleName, e.message, e)
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,9 @@ spring:
           starttls:
             enable: true
             required: true
-          connectiontimeout: 5000
-          timeout: 5000
-          writetimeout: 5000
+          connectiontimeout: 10000
+          timeout: 10000
+          writetimeout: 10000
 
   # Google OAuth2
   security:


### PR DESCRIPTION
fix: 이메일 발송 기능 개선 및 로깅 추가

- @EnableAsync 추가하여 비동기 이메일 발송 활성화
- MailService에 상세한 로깅 추가 (시작/성공/실패/예외별 처리)
- 이메일 설정 초기화 시점에 설정 확인 로그 추가
- ArticleEventListener에 이벤트 처리 로그 추가
- SMTP 타임아웃 설정을 5초에서 10초로 증가

배포 환경에서 이메일 발송 실패 원인을 파악할 수 있도록
다양한 예외 상황에 대한 상세 로깅을 추가했습니다
